### PR TITLE
Detect TS only in body of METAR

### DIFF
--- a/rpi_metar/airports.py
+++ b/rpi_metar/airports.py
@@ -85,7 +85,7 @@ class Airport(object):
             return
 
         # Thunderstorms
-        self.thunderstorms = any(word in metar['raw_text'] for word in ['TSRA', 'VCTS']) and self.category != wx.FlightCategory.OFF
+        self.thunderstorms = any(word in metar['raw_text'] for word in ['TSRA', 'VCTS', 'TS ']) and self.category != wx.FlightCategory.OFF
 
         # Wind info
         try:


### PR DESCRIPTION
The code for checking if a metar contains any TS is missing one qualifyer.

TS can appear alone in a metar:

> KPBI 011956Z 14015KT 10SM TS SCT027CB SCT090 BKN250 32/21 A2991 RMK AO2 LTG DSNT N TSB56 OCNL LTGICCC NW-N TS NW-N MOV SE T03220206

This line does not detect that TS by itself

https://github.com/ScottSturdivant/rpi_metar/blob/7b67181c3d5b59ead807a4c06cb7fc9f8293a5bb/rpi_metar/airports.py#L88

I propose the line be:
```python
self.thunderstorms = any(word in metar['raw_text'] for word in ['TSRA', 'VCTS', 'TS ']) and self.category != wx.FlightCategory.OFF
```

By adding the "TS "(with a space) you will catch all the TS in the body of the metar